### PR TITLE
 Fix for arbitrary code execution while unpickling in ipycache.load_vars() method.

### DIFF
--- a/ipycache.py
+++ b/ipycache.py
@@ -19,7 +19,6 @@ from IPython.utils.io import CapturedIO, capture_output
 from IPython.display import clear_output
 import hashlib
 
-
 #------------------------------------------------------------------------------
 # Six utility functions for Python 2/3 compatibility
 #------------------------------------------------------------------------------
@@ -115,6 +114,7 @@ def load_vars(path, vars):
     with open(path, 'rb') as f:
         # Load the variables from the cache.
         try:
+            restricted_loads(f.read())
             cache = pickle.load(f)
         except EOFError as e:
             cache={}
@@ -151,8 +151,26 @@ def save_vars(path, vars_d):
     """
     with open(path, 'wb') as f:
         dump(vars_d, f)
-    
-    
+
+
+# ------------------------------------------------------------------------------
+# RestrictedUnpickler - For mitigating arbitrary code execution while unpickling
+# This function provides restriction of using only the io module
+# ------------------------------------------------------------------------------
+class RestrictedUnpickler(pickle.Unpickler):
+
+    def find_class(self, module, name):
+        if module == '_io' and name == 'StringIO':
+            return getattr(sys.modules[module], name)
+        # Forbid everything else.
+        raise pickle.UnpicklingError("global '%s.%s' is forbidden" %
+                                     (module, name))
+
+
+def restricted_loads(s):
+    """Helper function analogous to pickle.loads()."""
+    return RestrictedUnpickler(io.BytesIO(s)).load()
+
 #------------------------------------------------------------------------------
 # CapturedIO
 #------------------------------------------------------------------------------

--- a/ipycache.py
+++ b/ipycache.py
@@ -158,14 +158,21 @@ def save_vars(path, vars_d):
 # This function provides restriction of using only the io module
 # ------------------------------------------------------------------------------
 class RestrictedUnpickler(pickle.Unpickler):
+    safe_modules = {
+        '_io',
+        'builtins'
+    }
+
+    safe_builtins = {
+        'StringIO'
+    }
 
     def find_class(self, module, name):
-        if module == '_io' and name == 'StringIO':
+        if module in self.safe_modules and name in self.safe_builtins:
             return getattr(sys.modules[module], name)
         # Forbid everything else.
         raise pickle.UnpicklingError("global '%s.%s' is forbidden" %
                                      (module, name))
-
 
 def restricted_loads(s):
     """Helper function analogous to pickle.loads()."""

--- a/test_ipycache.py
+++ b/test_ipycache.py
@@ -220,4 +220,8 @@ def test_load_exploitPickle():
     path = "malicious.pkl"
     with open("malicious.pkl", "wb") as f:
         pickle.dump(payload, f)
+
+    # Check that the cache read raises an UnpicklingError exception
     assert_raises(pickle.UnpicklingError, load_vars, path, ['a'])
+
+    os.remove(path)

--- a/test_ipycache.py
+++ b/test_ipycache.py
@@ -206,3 +206,18 @@ def test_cache_fail_1():
           ip_user_ns=user_ns, ip_run_cell=ip_run_cell, ip_push=ip_push)
     
     os.remove(path)
+
+
+def test_load_exploitPickle():
+    class vulnLoad():
+        def __init__(self):
+            self.a = 1
+
+        def __reduce__(self):
+            return (os.system, ('uname -a',))
+
+    payload = vulnLoad()
+    path = "malicious.pkl"
+    with open("malicious.pkl", "wb") as f:
+        pickle.dump(payload, f)
+    assert_raises(pickle.UnpicklingError, load_vars, path, ['a'])


### PR DESCRIPTION
Have an Unpickler which would check if the deserialized bytes stream a built-in function and restrict it if neccessary. Like [here](https://github.com/moreati/pickle-fuzz#pickle)
Any malicious command trying to process through the unpickle command would have to go through the restricted_loads() method which only allows io.StringsIO to parse.
Anything else, and it would raise a UnpicklingError.